### PR TITLE
FIX saving wallet pass in android_complete

### DIFF
--- a/android_complete/app/src/main/java/com/google/android/gms/samples/wallet/activity/CheckoutActivity.kt
+++ b/android_complete/app/src/main/java/com/google/android/gms/samples/wallet/activity/CheckoutActivity.kt
@@ -58,7 +58,7 @@ class CheckoutActivity : AppCompatActivity() {
         // TODO: Set an on-click listener on the "Add to Google Wallet" button
         addToGoogleWalletButton = layout.addToGoogleWalletButton.root
         addToGoogleWalletButton.setOnClickListener {
-            walletClient.savePasses(
+            walletClient.savePassesJwt(
                 TODO("Token goes here"),
                 this,
                 addToGoogleWalletRequestCode


### PR DESCRIPTION
As per the codelab texts, the correct call is savePassesJwt; not savePasses

Without this, the following error is produced:

```
Save error: {
 "errorCode": "INVALID_JSON",
 "errorMessage": "Not a JSON Object"
}
```